### PR TITLE
[GenArray] Add semantic analysis to preserve already defined types

### DIFF
--- a/Ryujinx.CustomTasks/GenerateArrays.cs
+++ b/Ryujinx.CustomTasks/GenerateArrays.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using Ryujinx.CustomTasks.SyntaxWalker;
 using Ryujinx.CustomTasks.Helper;
+using System.Linq;
 using Task = Microsoft.Build.Utilities.Task;
 
 namespace Ryujinx.CustomTasks
@@ -15,7 +16,7 @@ namespace Ryujinx.CustomTasks
         private const string InterfaceFileName = "IArray.g.cs";
         private const string ArraysFileName = "Arrays.g.cs";
 
-        private readonly List<string> _outputFiles = new List<string>();
+        private readonly HashSet<string> _outputFiles = new HashSet<string>();
 
         [Required]
         public string ArrayNamespace { get; set; }
@@ -58,7 +59,7 @@ namespace Ryujinx.CustomTasks
             _outputFiles.Add(filePath);
         }
 
-        private ICollection<int> GetArraySizes(string itemPath)
+        private HashSet<int> GetArraySizes(string itemPath)
         {
             Log.LogMessage(MessageImportance.Low, $"Searching for StructArray types in: {itemPath}");
 

--- a/Ryujinx.CustomTasks/GenerateArrays.cs
+++ b/Ryujinx.CustomTasks/GenerateArrays.cs
@@ -25,7 +25,19 @@ namespace Ryujinx.CustomTasks
         public string OutputPath { get; set; }
 
         [Required]
-        public ITaskItem[] InputFiles { get; set; }
+        public bool ScanSolution { get; set; }
+
+        [Required]
+        public string SolutionDir { get; set; }
+
+        [Required]
+        public string ProjectDir { get; set; }
+
+        [Required]
+        public string NugetPackagePath { get; set; }
+
+        [Required]
+        public string TargetFramework { get; set; }
 
         [Output]
         public string[] OutputFiles { get; set; }
@@ -186,16 +198,14 @@ namespace Ryujinx.CustomTasks
             string arraysFilePath = Path.Combine(OutputPath, ArraysFileName);
             List<int> arraySizes = new List<int>();
 
-            foreach (var item in InputFiles)
+            foreach (var item in Directory.EnumerateFiles(ScanSolution ? SolutionDir: ProjectDir, "*.cs", SearchOption.AllDirectories))
             {
-                string fullPath = item.GetMetadata("FullPath");
-
-                if (fullPath.EndsWith(".g.cs") || fullPath.Contains(Path.Combine("obj","Debug")) || fullPath.Contains(Path.Combine("obj", "Release")))
+                if (item.EndsWith(".g.cs") || item.Contains(Path.Combine("obj","Debug")) || item.Contains(Path.Combine("obj", "Release")))
                 {
                     continue;
                 }
 
-                foreach (int size in GetArraySizes(fullPath))
+                foreach (int size in GetArraySizes(item))
                 {
                     if (!arraySizes.Contains(size))
                     {

--- a/Ryujinx.CustomTasks/GenerateArrays.cs
+++ b/Ryujinx.CustomTasks/GenerateArrays.cs
@@ -55,8 +55,20 @@ namespace Ryujinx.CustomTasks
 
         private void AddGeneratedSource(string filePath, string content)
         {
+            bool addToOutputFiles = true;
+
+            if (File.Exists(filePath))
+            {
+                File.Delete(filePath);
+                addToOutputFiles = false;
+            }
+
             File.WriteAllText(filePath, content);
-            _outputFiles.Add(filePath);
+
+            if (addToOutputFiles)
+            {
+                _outputFiles.Add(filePath);
+            }
         }
 
         private HashSet<int> GetArraySizes(string itemPath)
@@ -173,9 +185,6 @@ namespace Ryujinx.CustomTasks
             string interfaceFilePath = Path.Combine(OutputPath, InterfaceFileName);
             string arraysFilePath = Path.Combine(OutputPath, ArraysFileName);
             List<int> arraySizes = new List<int>();
-
-            File.Delete(interfaceFilePath);
-            File.Delete(arraysFilePath);
 
             foreach (var item in InputFiles)
             {

--- a/Ryujinx.CustomTasks/SyntaxWalker/ArraySizeCollector.cs
+++ b/Ryujinx.CustomTasks/SyntaxWalker/ArraySizeCollector.cs
@@ -6,7 +6,7 @@ namespace Ryujinx.CustomTasks.SyntaxWalker
 {
     class ArraySizeCollector : CSharpSyntaxWalker
     {
-        public ICollection<int> ArraySizes { get; } = new List<int>();
+        public HashSet<int> ArraySizes { get; } = new HashSet<int>();
 
         private void AddArrayString(string name)
         {
@@ -17,7 +17,7 @@ namespace Ryujinx.CustomTasks.SyntaxWalker
 
             string rawArrayType = name.Split('<')[0];
 
-            if (int.TryParse(rawArrayType.Substring(5), out int size) && !ArraySizes.Contains(size))
+            if (int.TryParse(rawArrayType.Substring(5), out int size))
             {
                 ArraySizes.Add(size);
             }

--- a/Ryujinx.CustomTasks/build/Ryujinx.CustomTasks.targets
+++ b/Ryujinx.CustomTasks/build/Ryujinx.CustomTasks.targets
@@ -3,16 +3,23 @@
 
     <!-- Task: GenerateArrays -->
 
-    <!-- Defining all sources files of the current project for the input parameter -->
+    <!-- Assign default values -->
+    <PropertyGroup>
+        <ArrayScanSolution Condition="'$(ArrayScanSolution)' == ''">false</ArrayScanSolution>
+    </PropertyGroup>
+
     <ItemGroup>
-        <ArrayInputFiles Condition="'$(ArrayInputFiles)' == ''" Include="$(MSBuildProjectDirectory)\**\*.cs" />
+        <ArrayInputFiles Condition="'$(ArrayScanSolution)' == 'false'" Include="$(MSBuildProjectDirectory)\**\*.cs" />
+        <ArrayInputFiles Condition="'$(ArrayScanSolution)' == 'true'" Include="$(SolutionDir)\**\*.cs" />
     </ItemGroup>
 
     <!--A target that generates code, which is executed before the compilation-->
     <!-- TODO: Make "Outputs" more generic -->
     <Target Name="BeforeCompile" Inputs="@(ArrayInputFiles)" Outputs="$(ArrayOutputPath)\Arrays.g.cs;$(ArrayOutputPath)\IArray.g.cs">
         <!--Calling our custom task -->
-        <GenerateArrays ArrayNamespace="$(ArrayNamespace)" InputFiles="@(ArrayInputFiles)" OutputPath="$(ArrayOutputPath)">
+        <GenerateArrays ArrayNamespace="$(ArrayNamespace)" ScanSolution="$(ArrayScanSolution)" OutputPath="$(ArrayOutputPath)"
+                        SolutionDir="$(SolutionDir)" ProjectDir="$(MSBuildProjectDirectory)" NugetPackagePath="$(NuGetPackageRoot)"
+                        TargetFramework="$(TargetFramework)">
             <!--Our generated files are included to be compiled-->
             <Output TaskParameter="OutputFiles" ItemName="Compile" />
         </GenerateArrays>


### PR DESCRIPTION
This PR changes the behavior of the `GenerateArray` task in the following ways:

- Input properties changed:
  - `InputFiles`(list of items) was replaced with `ScanSolution`(bool)
- Already defined StructArray types will no longer cause the generation of a new StructArray

Note:

In order to use semantic analysis we need to resolve all package references of every project getting processed.
Sadly there is no easy way to get them, so I added a few methods to hopefully resolve most of them correctly.
This also means there is a chance now that this task can fail if any references can't be resolved.

---

Depends on #1 